### PR TITLE
[3/3] Settings: alarms and no interrupt zen mode

### DIFF
--- a/res/values/custom_strings.xml
+++ b/res/values/custom_strings.xml
@@ -76,4 +76,6 @@
     <string name="mount_notification_title">Mount notification</string>
     <string name="mount_notification_summary">Display ongoing notification for mounted storage</string>
 
+    <string name="zen_mode_none_category">No interruptions</string>
+    <string name="zen_mode_alarms">Allow alarms</string>
 </resources>

--- a/res/xml/zen_mode_settings.xml
+++ b/res/xml/zen_mode_settings.xml
@@ -26,6 +26,19 @@
             android:persistent="false" />
 
     <PreferenceCategory
+        android:key="none"
+        android:title="@string/zen_mode_none_category" >
+
+        <SwitchPreference
+            android:key="alarms"
+            android:title="@string/zen_mode_alarms"
+            android:persistent="false"
+            android:switchTextOff=""
+            android:switchTextOn="" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
         android:key="important"
         android:title="@string/zen_mode_important_category" >
 

--- a/src/com/android/settings/notification/ZenModeSettings.java
+++ b/src/com/android/settings/notification/ZenModeSettings.java
@@ -72,6 +72,8 @@ public class ZenModeSettings extends SettingsPreferenceFragment implements Index
     private static final String KEY_MESSAGES = "messages";
     private static final String KEY_STARRED = "starred";
     private static final String KEY_EVENTS = "events";
+    private static final String KEY_NONE = "none";
+    private static final String KEY_ALARMS = "alarms";
     private static final String KEY_ALARM_INFO = "alarm_info";
 
     private static final String KEY_DOWNTIME = "downtime";
@@ -118,6 +120,7 @@ public class ZenModeSettings extends SettingsPreferenceFragment implements Index
         rt.put(R.string.zen_mode_downtime_mode_title, KEY_DOWNTIME_MODE);
         rt.put(R.string.zen_mode_automation_category, KEY_AUTOMATION);
         rt.put(R.string.manage_condition_providers, KEY_CONDITION_PROVIDERS);
+        rt.put(R.string.zen_mode_alarms, KEY_ALARMS);
         return rt;
     }
 
@@ -141,6 +144,7 @@ public class ZenModeSettings extends SettingsPreferenceFragment implements Index
     private Preference mEntry;
     private Preference mConditionProviders;
     private AlertDialog mDialog;
+    private SwitchPreference mAlarms;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -224,6 +228,23 @@ public class ZenModeSettings extends SettingsPreferenceFragment implements Index
                 if (DEBUG) Log.d(TAG, "onPrefChange allowEvents=" + val);
                 final ZenModeConfig newConfig = mConfig.copy();
                 newConfig.allowEvents = val;
+                return setZenModeConfig(newConfig);
+            }
+        });
+
+        final PreferenceCategory none =
+                (PreferenceCategory) root.findPreference(KEY_NONE);
+
+        mAlarms = (SwitchPreference) none.findPreference(KEY_ALARMS);
+        mAlarms.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                if (mDisableListeners) return true;
+                final boolean val = (Boolean) newValue;
+                if (val == mConfig.allowAlarms) return true;
+                if (DEBUG) Log.d(TAG, "onPrefChange allowAlarms=" + val);
+                final ZenModeConfig newConfig = mConfig.copy();
+                newConfig.allowAlarms = val;
                 return setZenModeConfig(newConfig);
             }
         });
@@ -405,6 +426,7 @@ public class ZenModeSettings extends SettingsPreferenceFragment implements Index
         mMessages.setChecked(mConfig.allowMessages);
         mStarred.setSelectedValue(mConfig.allowFrom);
         mEvents.setChecked(mConfig.allowEvents);
+        mAlarms.setChecked(mConfig.allowAlarms);
         updateStarredEnabled();
         if (mDowntimeSupported) {
             updateDays();


### PR DESCRIPTION
allow to exclude alarms from no interruptions

Change-Id: I81babffbef540bd4067fa326726d0c834062b145