### PR TITLE
Settings: dont add empty DashboardCategories

### DIFF
--- a/src/com/android/settings/SettingsActivity.java
+++ b/src/com/android/settings/SettingsActivity.java
@@ -1122,8 +1122,9 @@ public class SettingsActivity extends Activity
                             XmlUtils.skipCurrentTag(parser);
                         }
                     }
-
-                    target.add(category);
+                    if (category.getTilesCount() > 0) {
+                        target.add(category);
+                    }
                 } else {
                     XmlUtils.skipCurrentTag(parser);
                 }


### PR DESCRIPTION
I am tired of people asking about interface category :)

Change-Id: I7c7ec38f1a84f070822939a45af071f5125ef4e5